### PR TITLE
feat: Docker 데모에서 Cursor(debugpy) 원격 디버깅 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Docker remote debug (debugpy): pass into container, e.g. ROSA_DEBUGPY=1 ./demo.sh
+ROSA_DEBUGPY=
+ROSA_DEBUGPY_PORT=5678
+
 # LLM Provider: "openai" (default), "anthropic", or "ollama"
 LLM_PROVIDER=openai
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,31 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal"
+        },
+        {
+            // 3단계: 컨테이너에서 ROSA_DEBUGPY=1 로 ./demo.sh 후 `start` 실행 →
+            // "[ROSA_DEBUGPY] listening..." 에서 대기하는 동안 이 구성으로 Attach.
+            // 포트는 demo.sh / ROSA_DEBUGPY_PORT 와 동일해야 함 (기본 5678).
+            // 대화형 에이전트: redirectOutput 끔 — 켜면 출력은 디버그 콘솔로 가고
+            // 터미널의 `>` 와 입력이 갈라져 디버그 콘솔에 자연어를 넣다 오류가 난다.
+            "name": "Python: Docker debugpy (attach)",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "127.0.0.1",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/src",
+                    "remoteRoot": "/app/src"
+                },
+                {
+                    "localRoot": "${workspaceFolder}/src/turtle_agent/scripts",
+                    "remoteRoot": "/app/devel/lib/turtle_agent"
+                }
+            ],
+            "justMyCode": false
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Upgrade pip first, then install packages
 RUN python3.9 -m pip install --upgrade pip
-RUN python3.9 -m pip install --break-system-packages python-dotenv catkin_tools
+RUN python3.9 -m pip install --break-system-packages python-dotenv catkin_tools debugpy
 RUN rosdep update && \
     echo "source /opt/ros/noetic/setup.bash" >> /root/.bashrc && \
     echo "alias start='catkin build && source devel/setup.bash && roslaunch turtle_agent agent.launch'" >> /root/.bashrc && \

--- a/demo.sh
+++ b/demo.sh
@@ -79,21 +79,28 @@ docker build $PLATFORM_ARG --build-arg DEVELOPMENT=$DEVELOPMENT -t $CONTAINER_NA
 }
 
 echo "Running the Docker container..."
+# Remote debug: export ROSA_DEBUGPY=1 before running; macOS publishes debugpy port to the host.
+DEBUGPY_PORT="${ROSA_DEBUGPY_PORT:-5678}"
 if [ "$(uname)" = "Darwin" ]; then
     # macOS: Use host.docker.internal for X11
     docker run -it --rm --init --name $CONTAINER_NAME \
-        -e DISPLAY=host.docker.internal:0 \
+        -p "${DEBUGPY_PORT}:${DEBUGPY_PORT}" \
+        -e DISPLAY=192.168.38.39:0 \
         -e HEADLESS=$HEADLESS \
         -e DEVELOPMENT=$DEVELOPMENT \
+        -e ROSA_DEBUGPY="${ROSA_DEBUGPY:-}" \
+        -e ROSA_DEBUGPY_PORT="${DEBUGPY_PORT}" \
         -v "$PWD/src":/app/src \
         -v "$PWD/tests":/app/tests \
         $CONTAINER_NAME
 else
-    # Linux/WSL: Use unix socket
+    # Linux/WSL: Use unix socket (--network host: debugpy port is on the host without -p)
     docker run -it --rm --init --name $CONTAINER_NAME \
         -e DISPLAY=$DISPLAY \
         -e HEADLESS=$HEADLESS \
         -e DEVELOPMENT=$DEVELOPMENT \
+        -e ROSA_DEBUGPY="${ROSA_DEBUGPY:-}" \
+        -e ROSA_DEBUGPY_PORT="${DEBUGPY_PORT}" \
         -v /tmp/.X11-unix:/tmp/.X11-unix \
         -v "$PWD/src":/app/src \
         -v "$PWD/tests":/app/tests \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "rich",
     "pillow>=10.4.0",
     "numpy>=1.26.4",
+    "debugpy>=1.8.20",
 ]
 
 [project.optional-dependencies]

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -23,6 +23,7 @@ import dotenv
 import pyinputplus as pyip
 import rospy
 from langchain.agents import tool, Tool
+
 # from langchain_ollama import ChatOllama
 from rich.console import Console
 from rich.console import Group
@@ -38,23 +39,48 @@ from llm import get_llm
 from prompts import get_prompts
 
 
+def _maybe_attach_debugpy() -> None:
+    """Listen for debugpy when ROSA_DEBUGPY is enabled (Docker + host Cursor attach)."""
+    flag = os.environ.get("ROSA_DEBUGPY", "").strip().lower()
+    if flag not in ("1", "true", "yes"):
+        return
+    try:
+        port = int(os.environ.get("ROSA_DEBUGPY_PORT", "5678").strip())
+    except ValueError:
+        port = 5678
+    try:
+        import debugpy
+    except ImportError:
+        print(
+            "[ROSA_DEBUGPY] debugpy is not installed; rebuild the image or pip install debugpy.",
+            file=sys.stderr,
+        )
+        raise
+    debugpy.listen(("0.0.0.0", port))
+    print(
+        f"[ROSA_DEBUGPY] listening on 0.0.0.0:{port}; attach from host, then execution continues.",
+        flush=True,
+    )
+    debugpy.wait_for_client()
+
+
 class GracefulInterruptHandler:
     """Context manager to handle interrupts gracefully."""
-    
+
     def __init__(self, verbose: bool = True):
         self.interrupted = False
         self.original_handler = None
         self.verbose = verbose
-    
+
     def __enter__(self):
         self.interrupted = False
         self.original_handler = signal.signal(signal.SIGINT, self._handler)
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         signal.signal(signal.SIGINT, self.original_handler)
         return False
-    
+
     def _handler(self, signum, frame):
         self.interrupted = True
         if self.verbose:
@@ -196,7 +222,9 @@ class TurtleAgent(ROSA):
                 else:
                     await self.submit(input)
             except KeyboardInterrupt:
-                console.print("\n[yellow]Operation interrupted. Type 'exit' to quit or continue with a new query.[/yellow]")
+                console.print(
+                    "\n[yellow]Operation interrupted. Type 'exit' to quit or continue with a new query.[/yellow]"
+                )
                 # Clear any partial state
                 continue
             except Exception as e:
@@ -264,10 +292,10 @@ class TurtleAgent(ROSA):
                     async for event in self.astream(query):
                         if handler.interrupted:
                             break
-                        
-                        event["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[
-                            :-3
-                        ]
+
+                        event["timestamp"] = datetime.now().strftime(
+                            "%Y-%m-%d %H:%M:%S.%f"
+                        )[:-3]
                         if event["type"] == "token":
                             content += event["content"]
                             panel.renderable = Markdown(content)
@@ -361,5 +389,6 @@ def main():
 
 
 if __name__ == "__main__":
+    _maybe_attach_debugpy()
     rospy.init_node("rosa", log_level=rospy.INFO)
     main()

--- a/uv.lock
+++ b/uv.lock
@@ -589,6 +589,39 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/be/8bd693a0b9d53d48c8978fa5d889e06f3b5b03e45fd1ea1e78267b4887cb/debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64", size = 2099192, upload-time = "2026-01-29T23:03:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1b/85326d07432086a06361d493d2743edd0c4fc2ef62162be7f8618441ac37/debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642", size = 3088568, upload-time = "2026-01-29T23:03:31.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/60/3e08462ee3eccd10998853eb35947c416e446bfe2bc37dbb886b9044586c/debugpy-1.8.20-cp310-cp310-win32.whl", hash = "sha256:c29dd9d656c0fbd77906a6e6a82ae4881514aa3294b94c903ff99303e789b4a2", size = 5284399, upload-time = "2026-01-29T23:03:33.678Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/09d49106e770fe558ced5e80df2e3c2ebee10e576eda155dcc5670473663/debugpy-1.8.20-cp310-cp310-win_amd64.whl", hash = "sha256:3ca85463f63b5dd0aa7aaa933d97cbc47c174896dcae8431695872969f981893", size = 5316388, upload-time = "2026-01-29T23:03:35.095Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/92/1cb532e88560cbee973396254b21bece8c5d7c2ece958a67afa08c9f10dc/debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb", size = 5233481, upload-time = "2026-01-29T23:03:40.659Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6b/668f21567e3250463beb6a401e7d598baa2a0907224000d7f68b9442c243/debugpy-1.8.20-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:bff8990f040dacb4c314864da95f7168c5a58a30a66e0eea0fb85e2586a92cd6", size = 2100484, upload-time = "2026-01-29T23:04:09.929Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/49/223143d1da586b891f35a45515f152742ad85bfc10d2e02e697f65c83b32/debugpy-1.8.20-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:70ad9ae09b98ac307b82c16c151d27ee9d68ae007a2e7843ba621b5ce65333b5", size = 3081272, upload-time = "2026-01-29T23:04:11.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/24/9f219c9290fe8bee4f63f9af8ebac440c802e6181d7f39a79abcb5fdff2f/debugpy-1.8.20-cp39-cp39-win32.whl", hash = "sha256:9eeed9f953f9a23850c85d440bf51e3c56ed5d25f8560eeb29add815bd32f7ee", size = 5285196, upload-time = "2026-01-29T23:04:13.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f3/4a12d7b1b09e3b79ba6e3edfa0c677b8b8bdf110bc4b3607e0f29fb4e8b3/debugpy-1.8.20-cp39-cp39-win_amd64.whl", hash = "sha256:760813b4fff517c75bfe7923033c107104e76acfef7bda011ffea8736e9a66f8", size = 5317163, upload-time = "2026-01-29T23:04:15.264Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1062,6 +1095,7 @@ source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
     { name = "cffi" },
+    { name = "debugpy" },
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-core" },
@@ -1095,6 +1129,7 @@ ollama = [
 requires-dist = [
     { name = "azure-identity" },
     { name = "cffi" },
+    { name = "debugpy", specifier = ">=1.8.20" },
     { name = "langchain", specifier = "~=0.3.23" },
     { name = "langchain-anthropic", marker = "extra == 'all'", specifier = "~=0.3.12" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = "~=0.3.12" },


### PR DESCRIPTION
## 변경 내용
- Docker 이미지에 `debugpy` 설치, `demo.sh`에서 `ROSA_DEBUGPY`/`ROSA_DEBUGPY_PORT` 전달 및 macOS 포트 퍼블리시
- `turtle_agent.py`에서 환경 변수 활성화 시 `debugpy.listen` + `wait_for_client` 후 노드 기동
- `.vscode/launch.json`에 Remote Attach 구성 및 pathMappings
- `.env.example`, `pyproject.toml`, `uv.lock` 반영

## 변경 파일
- `Dockerfile`
- `demo.sh`
- `src/turtle_agent/scripts/turtle_agent.py`
- `.vscode/launch.json`
- `.env.example`
- `pyproject.toml`
- `uv.lock`

## 사용 요약
1. `ROSA_DEBUGPY=1 ./demo.sh` 후 컨테이너에서 `start`
2. listening 메시지 확인 뒤 호스트에서 `Python: Docker debugpy (attach)`
3. 채팅 입력은 Docker 터미널에서

Closes jongphago/rosa#1 (해당 이슈가 있으면 연결)

Made with [Cursor](https://cursor.com)