### PR TITLE
feat(turtle_agent): turtlesim pose를 1초 간격 JSONL로 기록 (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 docs
 .DS_Store
 .env
+logs/

--- a/src/turtle_agent/scripts/pose_logger.py
+++ b/src/turtle_agent/scripts/pose_logger.py
@@ -1,0 +1,187 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Periodic turtlesim pose logging to JSONL (ROS 1 / rospy only in PoseLogger)."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, TextIO
+
+POSE_LOG_INTERVAL_SEC = 1.0
+
+
+def resolve_log_root() -> Path:
+    """Log root: TURTLE_AGENT_LOG_ROOT if set, else ./logs from current working directory."""
+    env = os.environ.get("TURTLE_AGENT_LOG_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    return (Path.cwd() / "logs").resolve()
+
+
+def build_log_dir(
+    log_root: Path, date_str: str, session_id: str, turtle_id: str
+) -> Path:
+    """logs/<date>/location/<session>/<turtle>/"""
+    return log_root / date_str / "location" / session_id / turtle_id
+
+
+def pose_to_record(pose: Any, stamp: Any) -> Dict[str, Any]:
+    """
+    Build one JSON-serializable dict from a turtlesim Pose-like object and a time stamp.
+
+    stamp: rospy.Time or any object with .secs and .nsecs, or dict with those keys.
+    """
+    if hasattr(stamp, "secs"):
+        t_ros = {"secs": int(stamp.secs), "nsecs": int(stamp.nsecs)}
+    else:
+        t_ros = {"secs": int(stamp["secs"]), "nsecs": int(stamp["nsecs"])}
+    return {
+        "t_ros": t_ros,
+        "x": float(pose.x),
+        "y": float(pose.y),
+        "theta": float(pose.theta),
+        "linear_velocity": float(pose.linear_velocity),
+        "angular_velocity": float(pose.angular_velocity),
+    }
+
+
+class PoseLogger:
+    """
+    Subscribe to /{turtle_id}/pose and append one JSON line per period to pose.jsonl.
+    Requires rospy.AsyncSpinner (or similar) so callbacks run while the main thread is busy.
+    """
+
+    def __init__(
+        self,
+        turtle_id: Optional[str] = None,
+        period: Optional[float] = None,
+        log_root: Optional[Path] = None,
+    ):
+        self._turtle_id_param = turtle_id
+        self._period_param = period
+        self._log_root_override = log_root
+
+        self._lock = threading.Lock()
+        self._last_pose: Any = None
+        self._stopped = False
+
+        self._sub: Any = None
+        self._timer: Any = None
+        self._fp: Optional[TextIO] = None
+        self._path: Optional[Path] = None
+        self._shutdown_hooked = False
+
+    def start(self) -> None:
+        import rospy
+        from turtlesim.msg import Pose
+
+        if self._fp is not None:
+            return
+
+        self._stopped = False
+
+        turtle_id = self._turtle_id_param
+        if turtle_id is None:
+            turtle_id = rospy.get_param(
+                "~turtle_id",
+                os.environ.get("TURTLE_TURTLE_ID", "turtle1"),
+            )
+        turtle_id = str(turtle_id).replace("/", "")
+
+        period = self._period_param
+        if period is None:
+            period = float(rospy.get_param("~pose_log_interval", POSE_LOG_INTERVAL_SEC))
+
+        log_root = self._log_root_override or resolve_log_root()
+        session_id = str(uuid.uuid4())
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        log_dir = build_log_dir(log_root, date_str, session_id, turtle_id)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        self._path = log_dir / "pose.jsonl"
+        self._fp = open(self._path, "a", encoding="utf-8")
+
+        self._turtle_id = turtle_id
+        self._period = period
+
+        topic = f"/{turtle_id}/pose"
+        self._sub = rospy.Subscriber(topic, Pose, self._on_pose, queue_size=1)
+        self._timer = rospy.Timer(rospy.Duration(self._period), self._on_timer)
+
+        if not self._shutdown_hooked:
+            rospy.on_shutdown(self._on_ros_shutdown)
+            self._shutdown_hooked = True
+
+        rospy.loginfo(
+            "PoseLogger writing to %s (every %.3f s)", self._path, self._period
+        )
+
+    def _on_ros_shutdown(self) -> None:
+        self.stop()
+
+    def _on_pose(self, msg: Any) -> None:
+        with self._lock:
+            if not self._stopped:
+                self._last_pose = msg
+
+    def _on_timer(self, _event: Any) -> None:
+        import rospy
+
+        stamp = rospy.Time.now()
+        with self._lock:
+            if self._stopped or self._last_pose is None or self._fp is None:
+                return
+            rec = pose_to_record(self._last_pose, stamp)
+            line = json.dumps(rec, separators=(",", ":")) + "\n"
+            try:
+                self._fp.write(line)
+                self._fp.flush()
+            except OSError as e:
+                rospy.logwarn("PoseLogger write failed: %s", e)
+
+    def stop(self) -> None:
+        import rospy
+
+        with self._lock:
+            if self._stopped:
+                return
+            self._stopped = True
+
+        if self._timer is not None:
+            self._timer.shutdown()
+            self._timer = None
+        if self._sub is not None:
+            self._sub.unregister()
+            self._sub = None
+        if self._fp is not None:
+            try:
+                self._fp.flush()
+            except OSError:
+                pass
+            try:
+                self._fp.close()
+            except OSError:
+                pass
+            self._fp = None
+
+        if self._path is not None:
+            rospy.loginfo("PoseLogger stopped (%s)", self._path)
+            self._path = None
+
+        self._last_pose = None

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -17,6 +17,7 @@ import asyncio
 import os
 import signal
 import sys
+import threading
 from datetime import datetime
 
 import dotenv
@@ -35,6 +36,7 @@ from rosa import ROSA
 
 import tools.turtle as turtle_tools
 from help import get_help
+from pose_logger import PoseLogger
 from llm import get_llm
 from prompts import get_prompts
 
@@ -391,4 +393,19 @@ def main():
 if __name__ == "__main__":
     _maybe_attach_debugpy()
     rospy.init_node("rosa", log_level=rospy.INFO)
-    main()
+
+    # rospy.AsyncSpinner is missing in some stacks; a daemon spin thread is portable.
+    def _ros_spin() -> None:
+        rospy.spin()
+
+    spin_thread = threading.Thread(target=_ros_spin, name="rospy_spin", daemon=True)
+    spin_thread.start()
+
+    pose_logger = PoseLogger()
+    pose_logger.start()
+    try:
+        main()
+    finally:
+        pose_logger.stop()
+        rospy.signal_shutdown("turtle_agent exiting")
+        spin_thread.join(timeout=5.0)

--- a/tests/test_turtle_agent/__init__.py
+++ b/tests/test_turtle_agent/__init__.py
@@ -1,0 +1,1 @@
+# Turtle agent tests package

--- a/tests/test_turtle_agent/test_pose_logger.py
+++ b/tests/test_turtle_agent/test_pose_logger.py
@@ -1,0 +1,96 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import unittest
+import unittest.mock
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from pose_logger import (  # noqa: E402
+    POSE_LOG_INTERVAL_SEC,
+    build_log_dir,
+    pose_to_record,
+    resolve_log_root,
+)
+
+
+class TestBuildLogDir(unittest.TestCase):
+    def test_layout(self):
+        root = Path("/tmp/logs-root")
+        p = build_log_dir(root, "2026-04-23", "sess-1", "turtle1")
+        self.assertEqual(
+            p,
+            Path("/tmp/logs-root/2026-04-23/location/sess-1/turtle1"),
+        )
+
+
+class TestPoseToRecord(unittest.TestCase):
+    def test_with_dict_stamp(self):
+        pose = SimpleNamespace(
+            x=1.0,
+            y=2.0,
+            theta=0.5,
+            linear_velocity=0.1,
+            angular_velocity=0.2,
+        )
+        rec = pose_to_record(pose, {"secs": 10, "nsecs": 20})
+        self.assertEqual(
+            rec,
+            {
+                "t_ros": {"secs": 10, "nsecs": 20},
+                "x": 1.0,
+                "y": 2.0,
+                "theta": 0.5,
+                "linear_velocity": 0.1,
+                "angular_velocity": 0.2,
+            },
+        )
+
+    def test_with_object_stamp(self):
+        pose = SimpleNamespace(
+            x=0.0,
+            y=0.0,
+            theta=0.0,
+            linear_velocity=0.0,
+            angular_velocity=0.0,
+        )
+        stamp = SimpleNamespace(secs=3, nsecs=400000000)
+        rec = pose_to_record(pose, stamp)
+        self.assertEqual(rec["t_ros"], {"secs": 3, "nsecs": 400000000})
+
+
+class TestResolveLogRoot(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("TURTLE_AGENT_LOG_ROOT", None)
+
+    def test_env_override(self):
+        with unittest.mock.patch.dict(
+            os.environ, {"TURTLE_AGENT_LOG_ROOT": "/tmp/custom-logs"}
+        ):
+            self.assertEqual(resolve_log_root(), Path("/tmp/custom-logs").resolve())
+
+
+class TestPoseLogIntervalConstant(unittest.TestCase):
+    def test_default_one_second(self):
+        self.assertEqual(POSE_LOG_INTERVAL_SEC, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈

Closes #3

## 변경 요약

- `/{turtle_id}/pose` 구독 후 **1초 주기**로 `pose.jsonl`에 JSONL append (`flush` 매 샘플).
- 로그 경로: `logs/<YYYY-MM-DD>/location/<session_uuid>/<turtle_id>/pose.jsonl`
  - 루트: 환경 변수 `TURTLE_AGENT_LOG_ROOT`, 없으면 현재 작업 디렉터리의 `logs/`.
- 거북이 ID: `~turtle_id` 또는 `TURTLE_TURTLE_ID`(기본 `turtle1`). 주기: `~pose_log_interval`(기본 1.0초).
- `asyncio` 메인과 병행되도록 **`rospy.spin()` 데몬 스레드** 사용; 종료 시 `PoseLogger.stop()`, `rospy.signal_shutdown`, 스레드 `join`.
- `.gitignore`에 `logs/` 추가.
- `build_log_dir`, `pose_to_record`, `resolve_log_root` 단위 테스트 (`tests/test_turtle_agent/test_pose_logger.py`).

## 테스트

- `python3 -m unittest tests.test_turtle_agent.test_pose_logger -v`
- (선택) Noetic + turtlesim 실행 후 `pose.jsonl` 생성 및 1초 간격 증가 확인.

## 참고

- #4(충돌·Hub 에픽)와 별도 머지; 이후 단계에서 PoseHub와 통합 가능.

Made with [Cursor](https://cursor.com)