### PR TITLE
feat(turtle_agent): 기하 교차 판정 순수 모듈 및 단위 테스트

### DIFF
--- a/src/turtle_agent/scripts/collision_geometry.py
+++ b/src/turtle_agent/scripts/collision_geometry.py
@@ -1,0 +1,146 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""2D collision geometry for turtlesim-style overlap checks (no ROS imports).
+
+`CollisionMonitor` and similar code can import:
+
+- ``circle_circle_signed_gap`` — center distance minus sum of radii; &lt; 0 overlap, &gt; 0 separated.
+- ``circles_overlap`` — bool overlap/touch with optional ``eps`` tolerance.
+- ``point_in_circle`` — point inside or on the circle boundary.
+- ``point_circle_distance`` — signed distance (negative inside, zero on boundary, positive outside).
+- ``segment_intersects_disc`` — closed disc vs line segment (walls / polyline edges).
+- ``circle_intersects_aabb`` — circle vs axis-aligned box (first-order obstacle approximation).
+- ``any_segment_intersects_disc`` — any segment in an iterable hits the disc.
+
+All coordinates are plane Cartesian (e.g. turtlesim x, y). Uses only the standard library.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Tuple
+
+Point = Tuple[float, float]
+Segment = Tuple[Point, Point]
+
+
+def circle_circle_signed_gap(
+    cx1: float,
+    cy1: float,
+    r1: float,
+    cx2: float,
+    cy2: float,
+    r2: float,
+) -> float:
+    """Return (center distance) − (r1 + r2)."""
+    d = math.hypot(cx2 - cx1, cy2 - cy1)
+    return d - (r1 + r2)
+
+
+def circles_overlap(
+    cx1: float,
+    cy1: float,
+    r1: float,
+    cx2: float,
+    cy2: float,
+    r2: float,
+    *,
+    eps: float = 0.0,
+) -> bool:
+    """True if closed discs overlap or touch, within ``eps`` on the signed gap."""
+    return circle_circle_signed_gap(cx1, cy1, r1, cx2, cy2, r2) <= eps
+
+
+def point_in_circle(
+    px: float,
+    py: float,
+    cx: float,
+    cy: float,
+    r: float,
+    *,
+    eps: float = 0.0,
+) -> bool:
+    """True if the point lies inside the disc or on its boundary (within ``eps``)."""
+    return math.hypot(px - cx, py - cy) <= r + eps
+
+
+def point_circle_distance(
+    px: float, py: float, cx: float, cy: float, r: float
+) -> float:
+    """Signed distance from point to circle boundary (inside &lt; 0, outside &gt; 0)."""
+    return math.hypot(px - cx, py - cy) - r
+
+
+def _closest_point_on_segment(
+    x1: float, y1: float, x2: float, y2: float, px: float, py: float
+) -> Tuple[float, float]:
+    dx = x2 - x1
+    dy = y2 - y1
+    len_sq = dx * dx + dy * dy
+    if len_sq == 0.0:
+        return x1, y1
+    t = ((px - x1) * dx + (py - y1) * dy) / len_sq
+    t = max(0.0, min(1.0, t))
+    return x1 + t * dx, y1 + t * dy
+
+
+def segment_intersects_disc(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    cx: float,
+    cy: float,
+    r: float,
+    *,
+    eps: float = 0.0,
+) -> bool:
+    """True if the closed disc intersects the line segment (endpoints included)."""
+    qx, qy = _closest_point_on_segment(x1, y1, x2, y2, cx, cy)
+    dist = math.hypot(qx - cx, qy - cy)
+    return dist <= r + eps
+
+
+def circle_intersects_aabb(
+    cx: float,
+    cy: float,
+    r: float,
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+    *,
+    eps: float = 0.0,
+) -> bool:
+    """True if the closed disc intersects the closed axis-aligned rectangle."""
+    qx = min(max(cx, min_x), max_x)
+    qy = min(max(cy, min_y), max_y)
+    dist = math.hypot(cx - qx, cy - qy)
+    return dist <= r + eps
+
+
+def any_segment_intersects_disc(
+    segments: Iterable[Segment],
+    cx: float,
+    cy: float,
+    r: float,
+    *,
+    eps: float = 0.0,
+) -> bool:
+    """True if any ``((x1,y1),(x2,y2))`` segment intersects the closed disc."""
+    for (x1, y1), (x2, y2) in segments:
+        if segment_intersects_disc(x1, y1, x2, y2, cx, cy, r, eps=eps):
+            return True
+    return False

--- a/tests/test_turtle_agent/test_collision_geometry.py
+++ b/tests/test_turtle_agent/test_collision_geometry.py
@@ -1,0 +1,107 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from collision_geometry import (  # noqa: E402
+    any_segment_intersects_disc,
+    circle_circle_signed_gap,
+    circle_intersects_aabb,
+    circles_overlap,
+    point_circle_distance,
+    point_in_circle,
+    segment_intersects_disc,
+)
+
+
+class TestCirclesOverlap(unittest.TestCase):
+    def test_separated(self):
+        self.assertFalse(circles_overlap(0.0, 0.0, 1.0, 5.0, 0.0, 1.0))
+        self.assertGreater(circle_circle_signed_gap(0.0, 0.0, 1.0, 5.0, 0.0, 1.0), 0.0)
+
+    def test_overlapping(self):
+        self.assertTrue(circles_overlap(0.0, 0.0, 2.0, 1.0, 0.0, 2.0))
+        self.assertLess(circle_circle_signed_gap(0.0, 0.0, 2.0, 1.0, 0.0, 2.0), 0.0)
+
+    def test_touching_exactly(self):
+        # centers 3 apart, radii 1 and 2 -> touching
+        self.assertTrue(circles_overlap(0.0, 0.0, 1.0, 3.0, 0.0, 2.0))
+        self.assertAlmostEqual(
+            circle_circle_signed_gap(0.0, 0.0, 1.0, 3.0, 0.0, 2.0),
+            0.0,
+        )
+
+    def test_eps_treats_near_touch_as_overlap(self):
+        gap = circle_circle_signed_gap(0.0, 0.0, 1.0, 3.0 + 1e-12, 0.0, 2.0)
+        self.assertGreater(gap, 0.0)
+        self.assertFalse(circles_overlap(0.0, 0.0, 1.0, 3.0 + 1e-12, 0.0, 2.0, eps=0.0))
+        self.assertTrue(circles_overlap(0.0, 0.0, 1.0, 3.0 + 1e-12, 0.0, 2.0, eps=1e-9))
+
+
+class TestPointCircle(unittest.TestCase):
+    def test_inside_and_outside(self):
+        self.assertTrue(point_in_circle(0.0, 0.0, 1.0, 1.0, 2.0))
+        self.assertFalse(point_in_circle(5.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_point_circle_distance(self):
+        self.assertAlmostEqual(point_circle_distance(2.0, 0.0, 0.0, 0.0, 1.0), 1.0)
+        self.assertAlmostEqual(point_circle_distance(0.5, 0.0, 0.0, 0.0, 1.0), -0.5)
+
+
+class TestSegmentDisc(unittest.TestCase):
+    def test_segment_crosses_circle(self):
+        self.assertTrue(segment_intersects_disc(-2.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_segment_passes_outside(self):
+        self.assertFalse(segment_intersects_disc(3.0, 3.0, 5.0, 3.0, 0.0, 0.0, 1.0))
+
+    def test_degenerate_segment_is_point_inside(self):
+        self.assertTrue(segment_intersects_disc(0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 1.0))
+
+
+class TestCircleAabb(unittest.TestCase):
+    def test_circle_inside_box(self):
+        self.assertTrue(circle_intersects_aabb(0.5, 0.5, 0.1, 0.0, 0.0, 1.0, 1.0))
+
+    def test_circle_far_from_box(self):
+        self.assertFalse(circle_intersects_aabb(10.0, 10.0, 0.5, 0.0, 0.0, 1.0, 1.0))
+
+    def test_circle_touches_box_corner_exterior(self):
+        # Center (2,2): closest point on [0,1]^2 is (1,1); distance sqrt(2). Radius just encloses it.
+        d = math.hypot(1.0, 1.0)
+        self.assertTrue(circle_intersects_aabb(2.0, 2.0, d, 0.0, 0.0, 1.0, 1.0))
+        self.assertFalse(
+            circle_intersects_aabb(2.0, 2.0, d - 1e-9, 0.0, 0.0, 1.0, 1.0, eps=0.0)
+        )
+
+
+class TestAnySegmentIntersectsDisc(unittest.TestCase):
+    def test_one_hit(self):
+        segs = [((5.0, 5.0), (6.0, 5.0)), ((-1.0, 0.0), (1.0, 0.0))]
+        self.assertTrue(any_segment_intersects_disc(segs, 0.0, 0.0, 0.5))
+
+    def test_none_hit(self):
+        segs = [((3.0, 3.0), (4.0, 3.0)), ((3.0, 4.0), (4.0, 4.0))]
+        self.assertFalse(any_segment_intersects_disc(segs, 0.0, 0.0, 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용
- `src/turtle_agent/scripts/collision_geometry.py`: ROS 비의존 2D 기하 API(`math`만 사용). 원–원, 점–원, 선분–원(닫힌 원판), AABB–원, 선분 iterable 판정.
- `tests/test_turtle_agent/test_collision_geometry.py`: 원–원 분리/겹침/접촉/`eps` 및 점·선분·AABB 소수 케이스.

관련 이슈: https://github.com/jongphago/rosa/issues/5

## 테스트
- [x] `uv run python -m unittest discover -s tests/test_turtle_agent --verbose` 통과 (19개)
- [ ] CI (Noetic/Humble) — PR에서 확인 예정

Made with [Cursor](https://cursor.com)