### PR TITLE
feat(turtle_agent): ObstacleStore 통합 장애물 모델 및 스레드 안전 갱신 (#8)

### DIFF
--- a/src/turtle_agent/scripts/obstacle_store.py
+++ b/src/turtle_agent/scripts/obstacle_store.py
@@ -1,0 +1,174 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Thread-safe in-memory obstacle registry for collision checking (no ROS imports).
+
+Each :class:`Obstacle` is immutable. Geometry variants align with
+``collision_geometry`` so consumers can call overlap helpers without conversion:
+
+- :class:`CircleGeometry` — use ``cx, cy, r`` with ``circles_overlap``,
+  ``point_in_circle``, ``point_circle_distance``, ``segment_intersects_disc``.
+- :class:`SegmentsGeometry` — ``segments`` is ``tuple[Segment, ...]`` (same
+  ``Segment`` as in ``collision_geometry``); pass to ``any_segment_intersects_disc``.
+- :class:`AabbGeometry` — ``min_x, min_y, max_x, max_y`` with
+  ``circle_intersects_aabb`` (disc vs obstacle box).
+
+``ObstacleStore`` uses :class:`threading.RLock`. :meth:`snapshot` returns a tuple
+of obstacles consistent with a single lock acquisition (after purging expired
+``ephemeral`` entries), suitable for one collision-evaluation pass.
+
+Ephemeral TTL uses :func:`time.monotonic` deadlines in :attr:`Obstacle.expires_at`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, replace
+from typing import Dict, Literal, Optional, Tuple, Union
+
+from collision_geometry import Segment
+
+ObstacleKind = Literal["static", "ephemeral", "turtle"]
+
+
+@dataclass(frozen=True)
+class CircleGeometry:
+    cx: float
+    cy: float
+    r: float
+
+
+@dataclass(frozen=True)
+class SegmentsGeometry:
+    segments: Tuple[Segment, ...]
+
+
+@dataclass(frozen=True)
+class AabbGeometry:
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+
+
+ObstacleGeometry = Union[CircleGeometry, SegmentsGeometry, AabbGeometry]
+
+
+@dataclass(frozen=True)
+class Obstacle:
+    id: str
+    kind: ObstacleKind
+    geometry: ObstacleGeometry
+    expires_at: Optional[float]
+
+
+def _normalize_geometry(geometry: ObstacleGeometry) -> ObstacleGeometry:
+    if isinstance(geometry, SegmentsGeometry):
+        segs = tuple(
+            ((float(x1), float(y1)), (float(x2), float(y2)))
+            for (x1, y1), (x2, y2) in geometry.segments
+        )
+        return SegmentsGeometry(segs)
+    if isinstance(geometry, CircleGeometry):
+        return CircleGeometry(float(geometry.cx), float(geometry.cy), float(geometry.r))
+    return AabbGeometry(
+        float(geometry.min_x),
+        float(geometry.min_y),
+        float(geometry.max_x),
+        float(geometry.max_y),
+    )
+
+
+def _validate_obstacle(obstacle: Obstacle) -> None:
+    if obstacle.kind == "ephemeral":
+        if obstacle.expires_at is None:
+            raise ValueError(
+                "ephemeral obstacles require expires_at (monotonic deadline)"
+            )
+    elif obstacle.expires_at is not None:
+        raise ValueError("only ephemeral obstacles may set expires_at")
+
+
+def _copy_obstacle_for_snapshot(obstacle: Obstacle) -> Obstacle:
+    """Detach segment tuples so snapshots never share mutable views."""
+    g = obstacle.geometry
+    if isinstance(g, SegmentsGeometry):
+        segs = tuple(
+            ((float(x1), float(y1)), (float(x2), float(y2)))
+            for (x1, y1), (x2, y2) in g.segments
+        )
+        g = SegmentsGeometry(segs)
+        return replace(obstacle, geometry=g)
+    return obstacle
+
+
+class ObstacleStore:
+    """Thread-safe store: upsert/remove/get/snapshot with ephemeral expiry."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._items: Dict[str, Obstacle] = {}
+
+    def upsert(self, obstacle: Obstacle) -> None:
+        normalized = replace(obstacle, geometry=_normalize_geometry(obstacle.geometry))
+        _validate_obstacle(normalized)
+        with self._lock:
+            self._purge_expired_unlocked()
+            self._items[normalized.id] = normalized
+
+    def remove(self, obstacle_id: str) -> bool:
+        with self._lock:
+            self._purge_expired_unlocked()
+            if obstacle_id in self._items:
+                del self._items[obstacle_id]
+                return True
+            return False
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+
+    def get(self, obstacle_id: str) -> Optional[Obstacle]:
+        with self._lock:
+            self._purge_expired_unlocked()
+            ob = self._items.get(obstacle_id)
+            if ob is None:
+                return None
+            return _copy_obstacle_for_snapshot(ob)
+
+    def snapshot(self) -> Tuple[Obstacle, ...]:
+        with self._lock:
+            self._purge_expired_unlocked()
+            return tuple(_copy_obstacle_for_snapshot(o) for o in self._items.values())
+
+    def __len__(self) -> int:
+        with self._lock:
+            self._purge_expired_unlocked()
+            return len(self._items)
+
+    def purge_expired(self) -> None:
+        """Remove all obstacles past ``expires_at`` (monotonic)."""
+        with self._lock:
+            self._purge_expired_unlocked()
+
+    def _purge_expired_unlocked(self) -> None:
+        now = time.monotonic()
+        expired = [
+            oid
+            for oid, o in self._items.items()
+            if o.expires_at is not None and o.expires_at <= now
+        ]
+        for oid in expired:
+            del self._items[oid]

--- a/tests/test_turtle_agent/test_obstacle_store.py
+++ b/tests/test_turtle_agent/test_obstacle_store.py
@@ -1,0 +1,221 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import random
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from collision_geometry import (  # noqa: E402
+    any_segment_intersects_disc,
+    circle_intersects_aabb,
+    circles_overlap,
+)
+from obstacle_store import (  # noqa: E402
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+
+class TestObstacleStoreSingleThread(unittest.TestCase):
+    def test_upsert_snapshot_remove(self):
+        store = ObstacleStore()
+        o = Obstacle(
+            id="a",
+            kind="static",
+            geometry=CircleGeometry(1.0, 2.0, 0.5),
+            expires_at=None,
+        )
+        store.upsert(o)
+        snap = store.snapshot()
+        self.assertEqual(len(snap), 1)
+        self.assertEqual(snap[0].id, "a")
+        self.assertIsInstance(snap[0].geometry, CircleGeometry)
+        self.assertTrue(store.remove("a"))
+        self.assertFalse(store.remove("a"))
+        self.assertEqual(len(store.snapshot()), 0)
+
+    def test_clear(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("x", "static", CircleGeometry(0.0, 0.0, 1.0), None))
+        store.clear()
+        self.assertEqual(len(store), 0)
+
+    def test_ephemeral_expires_on_snapshot(self):
+        store = ObstacleStore()
+        deadline = time.monotonic() + 0.05
+        store.upsert(
+            Obstacle(
+                "e",
+                "ephemeral",
+                CircleGeometry(0.0, 0.0, 1.0),
+                deadline,
+            )
+        )
+        time.sleep(0.1)
+        self.assertEqual(len(store.snapshot()), 0)
+
+    def test_ephemeral_expires_on_get(self):
+        store = ObstacleStore()
+        deadline = time.monotonic() + 0.05
+        store.upsert(
+            Obstacle("e", "ephemeral", CircleGeometry(0.0, 0.0, 1.0), deadline)
+        )
+        time.sleep(0.1)
+        self.assertIsNone(store.get("e"))
+
+    def test_purge_expired(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "e",
+                "ephemeral",
+                CircleGeometry(0.0, 0.0, 1.0),
+                time.monotonic() - 1.0,
+            )
+        )
+        store.purge_expired()
+        self.assertEqual(len(store), 0)
+
+    def test_validation_ephemeral_requires_deadline(self):
+        with self.assertRaises(ValueError):
+            ObstacleStore().upsert(
+                Obstacle("bad", "ephemeral", CircleGeometry(0.0, 0.0, 1.0), None)
+            )
+
+    def test_validation_static_may_not_have_deadline(self):
+        with self.assertRaises(ValueError):
+            ObstacleStore().upsert(
+                Obstacle(
+                    "bad",
+                    "static",
+                    CircleGeometry(0.0, 0.0, 1.0),
+                    time.monotonic() + 10.0,
+                )
+            )
+
+    def test_snapshot_segments_detached_from_store_updates(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "s",
+                "static",
+                SegmentsGeometry((((0.0, 0.0), (1.0, 0.0)),)),
+                None,
+            )
+        )
+        snap0 = store.snapshot()
+        segs0 = snap0[0].geometry.segments
+        store.upsert(
+            Obstacle(
+                "s",
+                "static",
+                SegmentsGeometry((((0.0, 0.0), (2.0, 0.0)),)),
+                None,
+            )
+        )
+        self.assertEqual(len(segs0), 1)
+        self.assertEqual(segs0[0], ((0.0, 0.0), (1.0, 0.0)))
+
+    def test_collision_geometry_circle(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("c", "static", CircleGeometry(0.0, 0.0, 1.0), None))
+        ob = store.snapshot()[0]
+        g = ob.geometry
+        self.assertTrue(circles_overlap(0.5, 0.0, 0.5, g.cx, g.cy, g.r, eps=1e-9))
+
+    def test_collision_geometry_segments(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "w",
+                "static",
+                SegmentsGeometry((((-1.0, 0.0), (1.0, 0.0)),)),
+                None,
+            )
+        )
+        ob = store.snapshot()[0]
+        self.assertTrue(
+            any_segment_intersects_disc(ob.geometry.segments, 0.0, 0.25, 0.3)
+        )
+
+    def test_collision_geometry_aabb(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "b",
+                "static",
+                AabbGeometry(2.0, 2.0, 4.0, 4.0),
+                None,
+            )
+        )
+        ob = store.snapshot()[0]
+        b = ob.geometry
+        self.assertTrue(
+            circle_intersects_aabb(3.0, 3.0, 0.5, b.min_x, b.min_y, b.max_x, b.max_y)
+        )
+
+
+class TestObstacleStoreConcurrent(unittest.TestCase):
+    def test_concurrent_upsert_remove_snapshot(self):
+        store = ObstacleStore()
+        rng = random.Random(0)
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(4)
+
+        def worker(tid: int) -> None:
+            try:
+                barrier.wait()
+                for _ in range(200):
+                    op = rng.randint(0, 2)
+                    oid = f"{tid}_{rng.randint(0, 9)}"
+                    if op == 0:
+                        store.upsert(
+                            Obstacle(
+                                oid,
+                                "static",
+                                CircleGeometry(rng.random(), rng.random(), 0.1),
+                                None,
+                            )
+                        )
+                    elif op == 1:
+                        store.remove(oid)
+                    else:
+                        snap = store.snapshot()
+                        self.assertIsInstance(snap, tuple)
+                        for ob in snap:
+                            _ = ob.id
+            except BaseException as e:  # pragma: no cover - surfaced in test
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        self.assertEqual(len(store.snapshot()), len(store))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용
- `obstacle_store.py`: `threading.RLock` 기반 스레드 안전 저장소, `static` / `ephemeral` / `turtle` 종류, 기하 유니온(원·선분 집합·AABB), `time.monotonic()` TTL, `upsert` / `remove` / `get` / `snapshot` / `clear` / `purge_expired`.
- `test_obstacle_store.py`: 단위 테스트 및 다중 스레드 스모크 테스트. `collision_geometry`와의 연동을 일부 테스트에서 검증.

## 비범위
- ROS 토픽·서비스 노출, StaticMapLoader, `turtle_agent` 연동(후속 이슈).

## 테스트
- [x] `python3 -m unittest discover -s tests/test_turtle_agent -v` 로컬 통과
- [x] CI 통과

Closes #8

Made with [Cursor](https://cursor.com)