### PR TITLE
fix: agent_mode launch 인자 중복 선언 제거

### DIFF
--- a/src/turtle_agent/launch/agent.launch
+++ b/src/turtle_agent/launch/agent.launch
@@ -4,7 +4,6 @@
     <arg name="static_obstacles_file" default="$(find turtle_agent)/config/static_obstacles_turtlesim.yaml" />
     <arg name="draw_static_world" default="true" />
     <arg name="world_builder_required" default="true" />
-    <arg name="agent_mode" default="single" />
     <arg name="control_worker_count" default="2" />
     <arg name="control_reset_turtlesim" default="false" />
     <arg name="control_task_count" default="0" />
@@ -23,7 +22,6 @@
         <param name="static_obstacles_file" value="$(arg static_obstacles_file)" />
         <param name="draw_static_world" value="$(arg draw_static_world)" />
         <param name="world_builder_required" value="$(arg world_builder_required)" />
-        <param name="agent_mode" value="$(arg agent_mode)" />
         <param name="control_worker_count" value="$(arg control_worker_count)" />
         <param name="control_reset_turtlesim" value="$(arg control_reset_turtlesim)" />
         <param name="control_task_count" value="$(arg control_task_count)" />


### PR DESCRIPTION
## 연관 이슈
- Refs upstage-sesac-agentic-robotics/rosa#67

## 변경 내용
- `agent.launch`에서 중복 선언된 `agent_mode` arg를 제거했습니다.
- `agent.launch`에서 중복 등록된 `agent_mode` param을 제거했습니다.

## 테스트
- [x] `python3` XML parse로 `agent.launch` 파싱 확인
- [ ] `start` 실행 시 `agent_mode has already been declared` 오류 미발생 확인

## 영향 범위
- ROS launch 인자 선언
- `feat/control-agent/task-orchestration` 브랜치의 실행 시작 단계

Made with [Cursor](https://cursor.com)